### PR TITLE
Add customization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const webpackConfig = {
     rules: [
       // <loader rules here>
     ]
-  }
+  },
   plugins: [
     new webpack.NoEmitOnErrorsPlugin(),
   ]
@@ -63,3 +63,26 @@ module.exports = webpackConfig;
 **Compiled with errors**
 
 ![image](https://user-images.githubusercontent.com/1018196/35707809-14e12926-0760-11e8-9f67-af1eff6048ae.png)
+
+## Customizing
+
+See `index.js` for examples.
+
+- `window.__webpackEventColors__` [Object] Override default colors.
+- `window.__webpackEventStyles__` [Object] Override default CSS.
+- `window.__webpackEventElem__` [DOMElement] DOM Element to apply the style on. Default: `body`.
+- `{webpackEventColor}` Use this placeholder in your CSS rules.
+
+Please note that if you want to keep away custom configs from your production codebase, than you should add
+these inside your own modules.
+
+```js
+// In webpack config
+if (isDevServer) {
+  webpackConfig.entry.app.push(`./src/webpackStatusBar`);
+}
+
+// ./src/webpackStatusBar
+window.__webpackEventColors__ = { ... };
+require(`webpack-dev-server-status-bar`);
+```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ See `index.js` for examples.
 - `window.__webpackEventStyles__` [Object] Override default CSS.
 - `window.__webpackEventElem__` [DOMElement] DOM Element to apply the style on. Default: `body`.
 - `{webpackEventColor}` Use this placeholder in your CSS rules.
+- `[data-webpack-status]` Attribute to be used with CSS selectors. See colors objects for available values.
 
 Please note that if you want to keep away custom configs from your production codebase, than you should add
 these inside your own modules.

--- a/index.js
+++ b/index.js
@@ -3,15 +3,15 @@ const webpackEventColors = {
   invalid: `#a081ea`, // purple (compiling)
   warnings: `#dd731d`, // orange
   errors: `#e4567b`, // red
-  close: `#9bacbf`, // grey (socket disconnected),
-  ...window.__webpackEventColors__
+  close: `#9bacbf`, // grey (socket disconnected)
 };
+Object.assign(webpackEventColors, window.__webpackEventColors__);
 
 const webpackEventStyles = {
 	border: `2px solid`,
-	borderColor: '{webpackEventColor}',
-	...window.__webpackEventStyles__
+	borderColor: '{webpackEventColor}'
 };
+Object.assign(webpackEventStyles, window.__webpackEventStyles__);
 
 const webpackEventElem = window.__webpackEventElem__ || document.body;
 

--- a/index.js
+++ b/index.js
@@ -3,16 +3,32 @@ const webpackEventColors = {
   invalid: `#a081ea`, // purple (compiling)
   warnings: `#dd731d`, // orange
   errors: `#e4567b`, // red
-  close: `#9bacbf`, // grey (socket disconnected)
+  close: `#9bacbf`, // grey (socket disconnected),
+  ...window.__webpackEventColors__
 };
+
+const webpackEventStyles = {
+	border: `2px solid`,
+	borderColor: '{webpackEventColor}',
+	...window.__webpackEventStyles__
+};
+
+const webpackEventElem = window.__webpackEventElem__ || document.body;
 
 window.addEventListener(`message`, event => {
   const webpackPrefix = `webpack`;
   const eventType = event.data.type;
   if (eventType && eventType.startsWith(webpackPrefix)) {
     const webpackEvent = eventType.substr(webpackPrefix.length).toLowerCase();
-    const bodyStyle = window.document.body.style;
-    bodyStyle.borderTop = `2px solid ${webpackEventColors[webpackEvent]}`;
+	const styles = renderStyles(webpackEventStyles, webpackEventColors[webpackEvent]);
+    Object.assign(webpackEventElem.style, styles);
   }
 });
+
+function renderStyles(styles, color) {
+  for (const [key, value] of Object.entries(styles)) {
+    styles[key] = value.replace('{webpackEventColor}', color);
+  }
+  return styles;
+}
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ const webpackEventColors = {
 Object.assign(webpackEventColors, window.__webpackEventColors__);
 
 const webpackEventStyles = {
-	border: `2px solid`,
+	borderWidth: `2px 0 0 0`,
+	borderStyle: `solid`,
 	borderColor: '{webpackEventColor}'
 };
 Object.assign(webpackEventStyles, window.__webpackEventStyles__);

--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ window.addEventListener(`message`, event => {
     const webpackEvent = eventType.substr(webpackPrefix.length).toLowerCase();
 	const styles = renderStyles(webpackEventStyles, webpackEventColors[webpackEvent]);
     Object.assign(webpackEventElem.style, styles);
+    // Using setAttribute instead of dataset to support [data-*] selectors
+	webpackEventElem.setAttribute(`data-webpack-status`, webpackEvent);
   }
 });
 


### PR DESCRIPTION
This PR adds support for the followings:
- Override default colors for events
- Custom CSS rules
- Define element other than body
- Data attribute to be used as a CSS selector