### PR TITLE
Support for webpack progress and webpackStatusStyleFunction

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "mixpanel"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - '8'
+script:
+  - npm run lint
+branches:
+  only: master

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ module.exports = webpackConfig;
 
 ## Customizing
 
-See `index.js` for examples.
+See `index.js` for how they are used.
 
 - `window.__webpackEventColors__` [Object] Override default colors.
 - `window.__webpackEventStyles__` [Object] Override default CSS.
@@ -76,6 +76,8 @@ See `index.js` for examples.
 
 Please note that if you want to keep away custom configs from your production codebase, than you should add
 these inside your own modules.
+
+### Custom example
 
 ```js
 // In webpack config

--- a/index.js
+++ b/index.js
@@ -1,37 +1,70 @@
-const webpackEventColors = {
+// @ts-check
+/** @type {string} */
+const webpackStatusElemId = window[`__webpackStatusElemId__`] || `__webpack_status_bar__`;
+
+/** @type {HTMLElement} */
+let webpackStatusElem = window[`__webpackStatusElem__`] || document.getElementById(webpackStatusElemId);
+
+/** @type {{[color: string]: string}} */
+const webpackStatusColors = Object.assign({
   ok: `#39d183`, // green (connected and idle)
   invalid: `#a081ea`, // purple (compiling)
   warnings: `#dd731d`, // orange
   errors: `#e4567b`, // red
   close: `#9bacbf`, // grey (socket disconnected)
-};
-Object.assign(webpackEventColors, window.__webpackEventColors__);
+  progress: `#39d1cf`, // aqua
+}, window[`__webpackStatusColors__`]);
 
-const webpackEventStyles = {
-	borderWidth: `2px 0 0 0`,
-	borderStyle: `solid`,
-	borderColor: '{webpackEventColor}'
-};
-Object.assign(webpackEventStyles, window.__webpackEventStyles__);
-
-const webpackEventElem = window.__webpackEventElem__ || document.body;
-
-window.addEventListener(`message`, event => {
-  const webpackPrefix = `webpack`;
-  const eventType = event.data.type;
-  if (eventType && eventType.startsWith(webpackPrefix)) {
-    const webpackEvent = eventType.substr(webpackPrefix.length).toLowerCase();
-	const styles = renderStyles(webpackEventStyles, webpackEventColors[webpackEvent]);
-    Object.assign(webpackEventElem.style, styles);
-    // Using setAttribute instead of dataset to support [data-*] selectors
-	webpackEventElem.setAttribute(`data-webpack-status`, webpackEvent);
-  }
-});
-
-function renderStyles(styles, color) {
-  for (const [key, value] of Object.entries(styles)) {
-    styles[key] = value.replace('{webpackEventColor}', color);
-  }
-  return styles;
+/**
+ * @typedef {object} WebpackStatus
+ * @prop {string} event - name of event e.g `ok`, `invalid` `warnings` e.t.c
+ * @prop {string} color - css color from webpackStatusColors
+ * @prop {number} progress - progress percentage if event is `progress` else 100
+ * @prop {string} message - a progress message e.g `compiling`, `emitting` e.t.c
+ *
+ * @typedef {{[prop: string]: any}} WebpackStatusStyle
+ *
+ * @param {WebpackStatus} status
+ * @returns {WebpackStatusStyle} - a styles property bag
+ */
+function getWebpackStatusStyle(status) {
+  return {
+    backgroundColor: `${status.color}`,
+    height: `2px`,
+    position: `fixed`,
+    top: `0px`,
+    width: `${status.progress}vw`,
+  };
 }
 
+/** @type {(status: WebpackStatus) => WebpackStatusStyle} */
+const webpackStatusStyleFunction = window[`__webpackStatusStyleFunction__`] || getWebpackStatusStyle;
+
+
+// webpack-dev-server sends messages with `webpack` prefix via postMessage
+// we handle the message and display a status bar on the top of the page
+window.addEventListener(`message`, event => {
+  const webpackEventPrefix = `webpack`;
+  const {type: eventType, data: eventData = {}} = event.data;
+
+  if (eventType && eventType.startsWith(webpackEventPrefix)) {
+    const event = eventType.substr(webpackEventPrefix.length).toLowerCase();
+    const progress = (event === `progress`) ? eventData.percent : 100;
+    const color = webpackStatusColors[event] || webpackStatusColors.invalid;
+    const message = eventData.msg || ``;
+
+    // create a div node with id, if there is no user defined status elem found
+    if (!webpackStatusElem) {
+      webpackStatusElem = document.createElement(`div`);
+      webpackStatusElem.setAttribute(`id`, webpackStatusElemId);
+      document.body.appendChild(webpackStatusElem);
+    }
+
+    // assign computed style to status bar
+    const statusStyle = webpackStatusStyleFunction({event, color, progress, message});
+    Object.assign(webpackStatusElem.style, statusStyle);
+
+    // using setAttribute instead of dataset to support [data-*] selectors
+    webpackStatusElem.setAttribute(`data-webpack-status`, event);
+  }
+});

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
-// @ts-check
+/** @type {any} cast to any so tsc doesn't complain about special window vars*/
+const global = window;
+
 /** @type {string} */
-const webpackStatusElemId = window[`__webpackStatusElemId__`] || `__webpack_status_bar__`;
+const webpackStatusElemId = global.__webpackStatusElemId__ || `__webpack_status_bar__`;
 
 /** @type {HTMLElement} */
-let webpackStatusElem = window[`__webpackStatusElem__`] || document.getElementById(webpackStatusElemId);
+let webpackStatusElem = global.__webpackStatusElem__ || document.getElementById(webpackStatusElemId);
 
 /** @type {{[color: string]: string}} */
 const webpackStatusColors = Object.assign({
@@ -13,7 +15,7 @@ const webpackStatusColors = Object.assign({
   errors: `#e4567b`, // red
   close: `#9bacbf`, // grey (socket disconnected)
   progress: `#39d1cf`, // aqua
-}, window[`__webpackStatusColors__`]);
+}, global.__webpackStatusColors__);
 
 /**
  * @typedef {object} WebpackStatus
@@ -38,7 +40,7 @@ function getWebpackStatusStyle(status) {
 }
 
 /** @type {(status: WebpackStatus) => WebpackStatusStyle} */
-const webpackStatusStyleFunction = window[`__webpackStatusStyleFunction__`] || getWebpackStatusStyle;
+const webpackStatusStyleFunction = global.__webpackStatusStyleFunction__ || getWebpackStatusStyle;
 
 
 // webpack-dev-server sends messages with `webpack` prefix via postMessage

--- a/index.js
+++ b/index.js
@@ -30,10 +30,12 @@ const webpackStatusColors = Object.assign({
  * @returns {WebpackStatusStyle} - a styles property bag
  */
 function getWebpackStatusStyle(status) {
+  // mobile devices don't deal well with position: fixed, fallback to absolute if it looks like touch device
+  const position = window.navigator.maxTouchPoints > 0 ? `absolute`: `fixed`;
   return {
     backgroundColor: `${status.color}`,
     height: `2px`,
-    position: `fixed`,
+    position,
     top: `0px`,
     width: `${status.progress}vw`,
   };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Shows webpack status as a thin colored bar on top of browser page",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint index.js"
   },
   "repository": {
     "type": "git",
@@ -20,5 +21,9 @@
   "bugs": {
     "url": "https://github.com/mixpanel/webpack-dev-server-status-bar/issues"
   },
-  "homepage": "https://github.com/mixpanel/webpack-dev-server-status-bar#readme"
+  "homepage": "https://github.com/mixpanel/webpack-dev-server-status-bar#readme",
+  "devDependencies": {
+    "eslint": "4.18.1",
+    "eslint-config-mixpanel": "3.5.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Shows webpack status as a thin colored bar on top of browser page",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint index.js"
+    "lint": "eslint index.js && tsc"
   },
   "repository": {
     "type": "git",
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/mixpanel/webpack-dev-server-status-bar#readme",
   "devDependencies": {
     "eslint": "4.18.1",
-    "eslint-config-mixpanel": "3.5.0"
+    "eslint-config-mixpanel": "3.5.0",
+    "typescript": "2.9.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "lib": ["dom", "es2018"],
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "files": [
+    "index.js"
+  ]
+}


### PR DESCRIPTION
Sent webpack-dev-server a PR for progress: https://github.com/webpack/webpack-dev-server/pull/1427/files

Based on that this makes the status bar a progress bar that's fixed on top of page. 

Refactoring code to support some custom overrides including a custom __webpackStatusStyleFunction__ that returns style based on a status object.

Will merge this PR after @wintercounter's #2 goes in.